### PR TITLE
Support old react native versions under 0.74

### DIFF
--- a/android/src/main/java/com/sourcepoint/reactnativecmp/RNSourcepointCmpModule.kt
+++ b/android/src/main/java/com/sourcepoint/reactnativecmp/RNSourcepointCmpModule.kt
@@ -101,7 +101,10 @@ class RNSourcepointCmpModule internal constructor(context: ReactApplicationConte
   }
 
   @ReactMethod
-  override fun supportedEvents() = SDKEvent.entries.map { name }.toTypedArray()
+  override fun supportedEvents(): Array<String> {
+    return SDKEvent.values().map { it.name }.toTypedArray()
+  }
+  
   private fun sendEvent(event: SDKEvent, params: WritableMap? = null) = reactApplicationContext
     .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
     .emit(event.name, params)


### PR DESCRIPTION
**Problem**: Sdk does not work with React Native version under 0.74 i.e ("react-native": "0.73.7",). This is due to that SDK:s Kotlin code, that seems to be using Kotlin 1.9 feature in single section.

**Solution**: 

- Replacing `SDKEvent.entries` with `SDKEvent.values`