### PR TITLE
Add customActionId to onAction payload

### DIFF
--- a/android/src/main/java/com/sourcepoint/reactnativecmp/RNSourcepointCmpModule.kt
+++ b/android/src/main/java/com/sourcepoint/reactnativecmp/RNSourcepointCmpModule.kt
@@ -119,6 +119,7 @@ class RNSourcepointCmpModule internal constructor(context: ReactApplicationConte
   override fun onAction(view: View, consentAction: ConsentAction): ConsentAction {
     sendEvent(SDKEvent.onAction, createMap().apply {
       putString("actionType", RNSourcepointActionType.from(consentAction.actionType).name)
+      putString("customActionId", consentAction.customActionId ?: "")
     })
     return consentAction
   }

--- a/ios/RNSourcepointCmp.swift
+++ b/ios/RNSourcepointCmp.swift
@@ -69,7 +69,10 @@ extension RNSourcepointCmp: SPDelegate {
     func onAction(_ action: SPAction, from controller: UIViewController) {
         RNSourcepointCmp.shared?.sendEvent(
             withName: "onAction",
-            body: ["actionType": RNSourcepointActionType(from: action.type).rawValue]
+            body: [
+              "actionType": RNSourcepointActionType(from: action.type).rawValue,
+              "customActionId": action.customActionId ?? "",
+            ]
         )
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,7 +67,12 @@ export class SPConsentManager implements Spec {
     RNSourcepointCmp.loadUSNatPrivacyManager(pmId);
   }
 
-  onAction(callback: (body: { actionType: SPActionType }) => void): void {
+  onAction(
+    callback: (body: {
+      actionType: SPActionType;
+      customActionId: string;
+    }) => void
+  ): void {
     this.emitter.removeAllListeners('onAction');
     this.emitter.addListener('onAction', callback);
   }


### PR DESCRIPTION
This PR adds the customActionId attribute to the onAction payload. When the type of action is Custom, this attribute will contain the ID assigned to it when building the message in the publisher's portal using the message builder. This enhancement allows developers to identify and handle custom actions more effectively within their applications.