### PR TITLE
Fix passing targeting params on android

### DIFF
--- a/android/src/main/java/com/sourcepoint/reactnativecmp/RNSourcepointCmpTypes.kt
+++ b/android/src/main/java/com/sourcepoint/reactnativecmp/RNSourcepointCmpTypes.kt
@@ -16,7 +16,7 @@ data class SPCampaign(
   val rawTargetingParam: ReadableMap?,
   val supportLegacyUSPString: Boolean
 ) {
-  val targetingParams = rawTargetingParam?.toHashMap()?.map { TargetingParam(it.key, it.toString()) } ?: emptyList()
+  val targetingParams = rawTargetingParam?.toHashMap()?.map { TargetingParam(it.key, it.value.toString()) } ?: emptyList()
 }
 
 data class SPCampaigns(


### PR DESCRIPTION
This PR fixes the issue with passing targeting parameters on Android. Previously, the targeting parameters were incorrectly formatted as:

```
targetingParams: { param: 'param=true' }
```

With this fix, the targeting parameters will now be correctly formatted as:

```
targetingParams: { param: 'true' }
```