### PR TITLE
[DIA-5989] `loadMessage()` without `authId` : fix for ios

### DIFF
--- a/src/NativeReactNativeCmp.ts
+++ b/src/NativeReactNativeCmp.ts
@@ -234,7 +234,7 @@ export interface Spec extends TurboModule {
     options?: SPBuildOptions,
   ): void;
   getUserData(): Promise<SPUserData>;
-  loadMessage(params?: LoadMessageParams): void;
+  loadMessage(params: LoadMessageParams): void;
   clearLocalData(): void;
   loadGDPRPrivacyManager(pmId: string): void;
   loadUSNatPrivacyManager(pmId: string): void;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -61,7 +61,7 @@ export default class SPConsentManager implements Spec {
   }
 
   loadMessage(params?: LoadMessageParams) {
-    ReactNativeCmp.loadMessage(params);
+    ReactNativeCmp.loadMessage(params ?? { authId: undefined });
   }
 
   clearLocalData() {


### PR DESCRIPTION
[DIA-5989](https://sourcepoint.atlassian.net/browse/DIA-5989)
React Native: Crash when calling loadMessage() without authId in package on iOS.